### PR TITLE
Join / Leave buttons fix and counter of spots left

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -52,7 +52,7 @@
           <%@event.participant_number-1 > @event.participants.count %>
       <%= button_to 'Join', event_participants_path(@event), method: :post, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-dark me-2" %>
           <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" %>
-          <p class= "mb-0 ms-2"><%= @event.participant_number - @event.participants.count-1  %> spots left!</p>
+          <%= pluralize(@event.participant_number - @event.participants.count - 1, 'spot') %> left!
           <% else %>
           <p class= "mb-0 me-2" > The event is full! </p>
           <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -37,24 +37,7 @@
     </div>
 
   <div>
-    <% if policy(@event).edit? %>
-      <%= button_to "Edit this event", edit_event_path(@event), class:"btn btn-dark"  %>
-    <% else %>
-      <%= button_to 'Join', event_participants_path(@event), method: :post, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-dark" %>
-      <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-dark" %>
-    <% end %>
-    <p><%= @event.participant_number %> spots left</p>
-
     <div class="horizontal-spacer"></div>
-
-    <%# Participants Section %>
-    <h6>Participants</h6>
-    <ul class="list-group">
-      <% @event.participants.each do |participant| %>
-        <li class="list-group-item"><%= participant.user.first_name%></li>
-      <% end %>
-    </ul>
-
 
     <%# Edit/destroy Event buttons Section %>
     <div>
@@ -63,10 +46,41 @@
       <% end %>
       <% if policy(@event).destroy? %>
         <%= link_to "Delete Event", event_path(@event), class: "btn btn-outline-dark", data: {turbo_method: :delete, turbo_confirm: "Are you sure?"} %>
+      <% else %>
+      <div class= "d-flex flex-row align-items-center" >
+        <%if %>
+          <%@event.participant_number-1 > @event.participants.count %>
+      <%= button_to 'Join', event_participants_path(@event), method: :post, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-dark me-2" %>
+          <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" %>
+          <p class= "mb-0 ms-2"><%= @event.participant_number - @event.participants.count-1  %> spots left!</p>
+          <% else %>
+          <p class= "mb-0 me-2" > The event is full! </p>
+          <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" %>
+        <%end %>
       <% end %>
-      <%= link_to "Back", events_path, class: "btn btn-outline-dark" %>
-    </div>
+       </div>
 
+       <div class="horizontal-spacer"></div>
+
+    <%# Participants Section %>
+    <h6>Participants</h6>
+    <ul class="list-group">
+      <% if policy(@event).edit? %>
+        <li class="list-group-item"><%= "You (Host)" %></li>
+          <% else %>
+        <li class="list-group-item"><%= @event.user.first_name%></li>
+          <%end %>
+      <% @event.participants.each do |participant| %>
+        <li class="list-group-item"><%= "#{participant.user.first_name} #{participant.user.last_name}"%></li>
+      <% end %>
+    </ul>
+
+      <div class="horizontal-spacer"></div>
+
+      <%= link_to "Back", events_path, class: "btn btn-outline-dark" %>
+
+
+  </div>
   </div>
 
   </div>


### PR DESCRIPTION
Test cases
  If you are NOT the owner of the event (sign up with different user to test) and you have signed up for the event you do not have a join button anymore. The counter of how many spots are left is gone.
  ![image](https://github.com/nathansoussana/local-sports-club/assets/45842463/d0f046d5-e3e4-4bf5-b705-7cc683f07e04)
  
  If you are NOT the owner of the event (sign up with different user to test) and you have not joined it yet you will see a join and leave button and how many spots are left 
  ![image](https://github.com/nathansoussana/local-sports-club/assets/45842463/e4cfd4c5-ab17-4bcc-850f-496ec01e66dd)
  
  If you are the OWNER of the event you can edit and delete it + you will be a participant of the event by default
  ![image](https://github.com/nathansoussana/local-sports-club/assets/45842463/07b78a56-976f-45eb-a9ca-b4c5276e3510)
  
  Once the sign up for the users is fixed I will add more info to the participants .. for now it's just the first name. Soon clicking on the name will take you to the user profile


