### PR TITLE
2 suggestions for the participation to an event

### DIFF
--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -52,7 +52,7 @@
           <%@event.participant_number-1 > @event.participants.count %>
           <%= button_to 'Join', event_participants_path(@event), method: :post, class:"btn btn-dark me-2" unless @participant = Participant.find_by(event: @event, user: current_user) %>
           <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" if @participant = Participant.find_by(event: @event, user: current_user) %>
-          <p><%= pluralize(@event.participant_number - @event.participants.count - 1, 'spot') %> left!</p>
+          <%= pluralize(@event.participant_number - @event.participants.count - 1, 'spot') %> left!
           <% else %>
           <p class= "mb-0 me-2" > The event is full! </p>
           <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" if @participant = Participant.find_by(event: @event, user: current_user) %>

--- a/app/views/events/show.html.erb
+++ b/app/views/events/show.html.erb
@@ -50,12 +50,12 @@
       <div class= "d-flex flex-row align-items-center" >
         <%if %>
           <%@event.participant_number-1 > @event.participants.count %>
-          <%= button_to 'Join', event_participants_path(@event), method: :post, class:"btn btn-dark me-2" %>
+          <%= button_to 'Join', event_participants_path(@event), method: :post, class:"btn btn-dark me-2" unless @participant = Participant.find_by(event: @event, user: current_user) %>
           <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" if @participant = Participant.find_by(event: @event, user: current_user) %>
-          <%= pluralize(@event.participant_number - @event.participants.count - 1, 'spot') %> left!
+          <p><%= pluralize(@event.participant_number - @event.participants.count - 1, 'spot') %> left!</p>
           <% else %>
           <p class= "mb-0 me-2" > The event is full! </p>
-          <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" %>
+          <%= button_to 'Leave', event_participant_path(@event), method: :delete, form: { data: { turbo_confirm: 'Are you sure?' } }, class:"btn btn-outline-dark" if @participant = Participant.find_by(event: @event, user: current_user) %>
         <%end %>
       <% end %>
        </div>


### PR DESCRIPTION
Hi @celiahalenke ,

By playing around with the participation feature further, I came across 2 enhancements proposals (apologies for the scattered feedback on this feature):

- First, when an event was full, it was showing me "Leave" while I hadn't joined it in the first place. I added a conditional statement so it only shows it to people who are actually participating to the event.
- Second, "Join" was still showing to users who'd have joined an event. You have successfully added the logic for "Leave", I added another conditional statement for "Join" as well.

Thank you!
Nathan